### PR TITLE
Subscribers have to ack received messages manually

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    event_bus (1.0.0)
-      bunny (~> 2.7.0)
+    event_bus_rb (2.0.0)
+      bunny (~> 2.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
     amq-protocol (2.2.0)
-    awesome_print (1.7.0)
+    awesome_print (1.8.0)
     bunny (2.7.0)
       amq-protocol (>= 2.2.0)
-    byebug (9.0.6)
-    coderay (1.1.1)
+    byebug (9.1.0)
+    coderay (1.1.2)
     diff-lcs (1.3)
     dotenv (2.2.1)
     method_source (0.8.2)
@@ -20,8 +20,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.4.2)
-      byebug (~> 9.0)
+    pry-byebug (3.5.0)
+      byebug (~> 9.1)
       pry (~> 0.10)
     pry-meta (0.0.10)
       awesome_print
@@ -53,10 +53,10 @@ PLATFORMS
 DEPENDENCIES
   bundler
   dotenv
-  event_bus!
+  event_bus_rb!
   pry-meta
   rake
   rspec
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ event_name = 'resource.origin.action'
 
 puts 'Start receiving messages'
 
-EventBus::Listener.on(event_name) do |event|
+EventBus::Listener.on(event_name) do |event, _delivery_info|
   puts ""
   puts "  - Received a message from #{event.name}:"
   puts "     Message: #{event.body}"
@@ -99,12 +99,16 @@ class CustomEventListener < EventBus::Listeners::Base
   bind :pay, 'resource.custom.pay'
   bind :receive, 'resource.custom.receive'
 
-  def pay(event)
+  def pay(event, delivery_info)
     puts "Paid #{event.body['amount']} for #{event.body['name']} ~> #{event.name}"
+
+    channel.ack(delivery_info.delivery_tag, false)
   end
 
-  def receive(event)
+  def receive(event, delivery_info)
     puts "Received #{event.body['amount']} from #{event.body['name']} ~> #{event.name}"
+
+    channel.ack(delivery_info.delivery_tag, false)
   end
 end
 ```

--- a/event_bus_rb.gemspec
+++ b/event_bus_rb.gemspec
@@ -27,11 +27,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 0'
-  spec.add_development_dependency 'rake', '~> 0'
-  spec.add_development_dependency 'rspec', '~> 0'
-  spec.add_development_dependency 'pry-meta', '~> 0'
-  spec.add_development_dependency 'dotenv', '~> 0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'pry-meta'
 
   spec.add_dependency 'bunny', '~> 2.7'
 end

--- a/examples/daemon.rb
+++ b/examples/daemon.rb
@@ -18,12 +18,19 @@ class CustomEventListener < EventBus::Listeners::Base
   bind :pay, 'resource.custom.pay'
   bind :receive, 'resource.custom.receive'
 
-  def pay(event)
+  def pay(event, delivery_info)
     puts "Paid #{event.body['amount']} for #{event.body['name']} ~> #{event.name}"
+
+    channel.acknowledge(delivery_info.delivery_tag, false)
   end
 
-  def receive(event)
-    puts "Received #{event.body['amount']} from #{event.body['name']} ~> #{event.name}"
+  def receive(event, delivery_info)
+    if event.body['amount'] > 42
+      channel.acknowledge(delivery_info.delivery_tag, false)
+      puts "Received #{event.body['amount']} from #{event.body['name']} ~> #{event.name}"
+    else
+      puts "[consumer] Got SKIPPED message"
+    end
   end
 end
 

--- a/examples/listener.rb
+++ b/examples/listener.rb
@@ -18,7 +18,7 @@ event_name = 'resource.origin.action'
 
 puts 'Start receiving messages'
 
-EventBus::Listener.on(event_name) do |event|
+EventBus::Listener.on(event_name) do |event, _delivery_info|
   puts ""
   puts "  - Received a message from #{event.name}:"
   puts "     Message: #{event.body}"

--- a/lib/event_bus/broker/rabbit/queue.rb
+++ b/lib/event_bus/broker/rabbit/queue.rb
@@ -28,7 +28,7 @@ module EventBus
 
         event = EventBus::Event.new(event_name, payload)
 
-        block.call(event, channel)
+        block.call(event, channel, delivery_info)
       end
 
       def topic

--- a/lib/event_bus/broker/rabbit/queue.rb
+++ b/lib/event_bus/broker/rabbit/queue.rb
@@ -14,7 +14,7 @@ module EventBus
 
         channel.queue(name, queue_options)
           .bind(topic, routing_key: routing_key)
-          .subscribe do |delivery_info, properties, payload|
+          .subscribe(manual_ack: true) do |delivery_info, properties, payload|
             callback(delivery_info, properties, payload, &block)
           end
       end
@@ -28,7 +28,7 @@ module EventBus
 
         event = EventBus::Event.new(event_name, payload)
 
-        block.call(event)
+        block.call(event, channel)
       end
 
       def topic

--- a/lib/event_bus/listeners/base.rb
+++ b/lib/event_bus/listeners/base.rb
@@ -1,6 +1,12 @@
 module EventBus
   module Listeners
     class Base
+      attr_reader :channel
+
+      def initialize(channel)
+        @channel = channel
+      end
+
       def self.bind(method, event_name)
         Manager.register_listener_configuration({
           listener_class: self,

--- a/lib/event_bus/listeners/manager.rb
+++ b/lib/event_bus/listeners/manager.rb
@@ -5,8 +5,8 @@ module EventBus
       class << self
         def bind_all_listeners
           listener_configurations.each do |config|
-            EventBus::Listener.on(config[:routing_key]) do |event|
-              config[:listener_class].new.send(config[:method], event)
+            EventBus::Listener.on(config[:routing_key]) do |event, channel|
+              config[:listener_class].new(channel).send(config[:method], event)
             end
           end
         end

--- a/lib/event_bus/listeners/manager.rb
+++ b/lib/event_bus/listeners/manager.rb
@@ -5,8 +5,8 @@ module EventBus
       class << self
         def bind_all_listeners
           listener_configurations.each do |config|
-            EventBus::Listener.on(config[:routing_key]) do |event, channel|
-              config[:listener_class].new(channel).send(config[:method], event)
+            EventBus::Listener.on(config[:routing_key]) do |event, channel, delivery_info|
+              config[:listener_class].new(channel).send(config[:method], event, delivery_info)
             end
           end
         end

--- a/lib/event_bus/version.rb
+++ b/lib/event_bus/version.rb
@@ -1,3 +1,3 @@
 module EventBus
-  VERSION = '1.1.0'
+  VERSION = '2.0.0'
 end

--- a/lib/event_bus_rb.rb
+++ b/lib/event_bus_rb.rb
@@ -1,8 +1,3 @@
-require 'dotenv'
-
-root = Dir.pwd
-Dotenv.load("#{root}/.env.local", "#{root}/.env.#{ENV['RACK_ENV']}", "#{root}/.env")
-
 require 'event_bus/version'
 require 'event_bus/daemon'
 require 'event_bus/event'

--- a/spec/event_bus/broker/rabbit/queue_spec.rb
+++ b/spec/event_bus/broker/rabbit/queue_spec.rb
@@ -1,8 +1,8 @@
 describe EventBus::Broker::Rabbit::Queue do
   let(:instance) { described_class.new(connection) }
-  let(:connection) { OpenStruct.new(queue: bindable) }
-  let(:bindable) { OpenStruct.new(bind: subscribable) }
-  let(:subscribable) { OpenStruct.new(subscribe: block) }
+  let(:connection) { double('conn', queue: bindable) }
+  let(:bindable) { double('bindable', bind: subscribable) }
+  let(:subscribable) { double('subscribable', subscribe: block) }
   let(:topic) { 'topic' }
   let(:event) { 'event' }
   let(:routing_key) { 'Routing_KEY' }
@@ -35,9 +35,6 @@ describe EventBus::Broker::Rabbit::Queue do
 
     before do
       allow(EventBus::Broker::Rabbit::Topic).to receive(:topic).and_return(topic)
-
-      allow(connection).to receive(:queue).and_return(bindable)
-      allow(bindable).to receive(:bind).and_return(subscribable)
     end
 
     subject { instance.subscribe(routing_key, &block) }
@@ -62,7 +59,7 @@ describe EventBus::Broker::Rabbit::Queue do
 
     context 'when message is received' do
       let(:event_name) { 'event_name' }
-      let(:delivery_info) { OpenStruct.new(routing_key: event_name) }
+      let(:delivery_info) { double('delivery_info', routing_key: event_name) }
       let(:properties) { 'properties' }
       let(:payload) { 'payload' }
       let(:subscribe_block) do
@@ -78,7 +75,7 @@ describe EventBus::Broker::Rabbit::Queue do
       it 'cals block with the received event' do
         subject
 
-        expect(block).to receive(:call).with(event)
+        expect(block).to receive(:call).with(event, connection, delivery_info)
 
         subscribe_block.call(delivery_info, properties, payload)
       end

--- a/spec/event_bus/broker/rabbit/topic_spec.rb
+++ b/spec/event_bus/broker/rabbit/topic_spec.rb
@@ -78,7 +78,9 @@ describe EventBus::Broker::Rabbit::Topic do
     end
 
     before do
-      allow(topic).to receive(:publish).with(payload_expected, routing_key: routing_key)
+      allow(topic).to receive(:publish).with(payload_expected,
+                                             routing_key: routing_key,
+                                             content_type: "application/json")
     end
 
     subject { described_class.produce(connection, event) }
@@ -100,7 +102,9 @@ describe EventBus::Broker::Rabbit::Topic do
       let(:event) { EventBus::Event.new(routing_key, body, schemaVersion) }
 
       it 'changes schemaVersion default' do
-        expect(topic).to receive(:publish).with(payload_expected, routing_key: routing_key)
+        expect(topic).to receive(:publish).with(payload_expected,
+                                                routing_key: routing_key,
+                                                content_type: 'application/json')
 
         subject
       end
@@ -124,7 +128,9 @@ describe EventBus::Broker::Rabbit::Topic do
     subject { instance.produce(event) }
 
     it 'publishes the event with correct params' do
-      expect(topic).to receive(:publish).with(payload_expected, routing_key: routing_key)
+      expect(topic).to receive(:publish).with(payload_expected,
+                                              routing_key: routing_key,
+                                              content_type: 'application/json')
 
       subject
     end

--- a/spec/event_bus_spec.rb
+++ b/spec/event_bus_spec.rb
@@ -1,5 +1,5 @@
 describe EventBus do
   it 'has a version number' do
-    expect(EventBus::VERSION).to eq '1.0.0'
+    expect(EventBus::VERSION).to eq '2.0.0'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,14 @@
+# Define all environment varibles for specs
+ENV['RABBIT_EVENT_BUS_APP_NAME'] = "app_name"
+ENV['RABBIT_EVENT_BUS_TOPIC_NAME'] = "event_bus"
+ENV['RABBIT_EVENT_BUS_VHOST'] = "event_bus"
+ENV['RABBIT_URL'] = "amqp://guest:guest@localhost:5672"
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 Bundler.require(:default, 'test')
 
 require 'rubygems'
-require 'dotenv/load'
-require 'event_bus'
 require 'pry'
 
 RSpec.configure do |config|


### PR DESCRIPTION
There is a strange behavior from Bunny when the subscriber do not start with the option `{ manual_ack: true }`. It simply consumes all messages from RabbitMQ even when it didn't have processed their before.

These simple lines can simulate that:

```ruby
channel.queue(name, queue_options)
  .bind(topic, routing_key: routing_key)
  .subscribe(block: true, manual_ack: true) do |delivery_info, properties, payload|
    puts "Received payload: #{payload}"
    sleep(100)
    # try to interrupt the process after payload has printed
end
```

With a large queue on RabbitMQ you can see what happened with that messages enqueued.

## Main changes

* Every subscribe on a queue has created with `manual_ack: true`. So who's receiving messages has to manually does acknowledge.
* Methods for bind expect for two arguments: `payload` and `delivery_info`
* `EventBus::Listeners::Base` has `channel` as attr_reader
* Change version to **2.0.0**

# Minor changes

* Remove `dotenv` dependency for development environment
* Update Gemfile.lock to get newer versions from gems

## Tasks

- [x] Define subscribe to have `manual_ack: true`
- [x] Expose `channel` and `delivery_info` for classes that inherent from `EventBus::Listeners::Base`
- [x] Update specs
- [x] Update documentation and examples