### PR TITLE
Give no more than one message to a worker at a time

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,6 @@ GEM
     byebug (9.1.0)
     coderay (1.1.2)
     diff-lcs (1.3)
-    dotenv (2.2.1)
     method_source (0.8.2)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -52,7 +51,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  dotenv
   event_bus_rb!
   pry-meta
   rake

--- a/lib/event_bus/broker/rabbit/queue.rb
+++ b/lib/event_bus/broker/rabbit/queue.rb
@@ -3,6 +3,7 @@ module EventBus
     class Rabbit::Queue
       def initialize(connection)
         @channel = connection
+        @channel.prefetch(1)
       end
 
       def self.subscribe(connection, routing_key, &block)

--- a/lib/event_bus/version.rb
+++ b/lib/event_bus/version.rb
@@ -1,3 +1,3 @@
 module EventBus
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/event_bus/broker/rabbit/queue_spec.rb
+++ b/spec/event_bus/broker/rabbit/queue_spec.rb
@@ -1,12 +1,24 @@
 describe EventBus::Broker::Rabbit::Queue do
   let(:instance) { described_class.new(connection) }
-  let(:connection) { double('conn', queue: bindable) }
+  let(:connection) { double('conn', queue: bindable, prefetch: 1) }
   let(:bindable) { double('bindable', bind: subscribable) }
   let(:subscribable) { double('subscribable', subscribe: block) }
   let(:topic) { 'topic' }
   let(:event) { 'event' }
   let(:routing_key) { 'Routing_KEY' }
   let(:block) { ->(event) { true } }
+
+  describe '.new' do
+    let(:connection) { double('conn', queue: bindable) }
+
+    subject { instance }
+
+    it 'set channel prefetch to 1' do
+      allow(connection).to receive(:prefetch).with(1)
+
+      subject
+    end
+  end
 
   describe '.subscribe' do
     before do

--- a/spec/event_bus_spec.rb
+++ b/spec/event_bus_spec.rb
@@ -1,5 +1,5 @@
 describe EventBus do
   it 'has a version number' do
-    expect(EventBus::VERSION).to eq '2.0.0'
+    expect(EventBus::VERSION).to eq '2.0.1'
   end
 end


### PR DESCRIPTION
Reference: **Fair dispatch** on [RabbitMQ Guides](https://www.rabbitmq.com/tutorials/tutorial-two-ruby.html)

We want to RabbitMQ give no more than one message to a worker at a time, preventing lost messages when some worker dies.