### PR TITLE
Recreate channel if channel is closed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    event_bus_rb (2.0.2)
+    event_bus_rb (2.0.3)
       bunny (~> 2.7)
 
 GEM

--- a/lib/event_bus/broker/rabbit.rb
+++ b/lib/event_bus/broker/rabbit.rb
@@ -23,6 +23,8 @@ module EventBus
 
       def channel
         @@channel ||= connection.create_channel
+        @@channel = connection.create_channel if @@channel.closed?
+        @@channel
       end
 
       def session

--- a/lib/event_bus/broker/rabbit/queue.rb
+++ b/lib/event_bus/broker/rabbit/queue.rb
@@ -1,13 +1,13 @@
 module EventBus
   module Broker
     class Rabbit::Queue
-      def initialize(connection)
-        @channel = connection
+      def initialize(channel)
+        @channel = channel
         @channel.prefetch(1)
       end
 
-      def self.subscribe(connection, routing_key, &block)
-        new(connection).subscribe(routing_key, &block)
+      def self.subscribe(channel, routing_key, &block)
+        new(channel).subscribe(routing_key, &block)
       end
 
       def subscribe(routing_key, &block)

--- a/lib/event_bus/broker/rabbit/topic.rb
+++ b/lib/event_bus/broker/rabbit/topic.rb
@@ -1,20 +1,20 @@
 module EventBus
   module Broker
     class Rabbit::Topic
-      def initialize(connection)
-        @channel = connection
+      def initialize(channel)
+        @channel = channel
       end
 
-      def self.topic(connection)
-        new(connection).topic
+      def self.topic(channel)
+        new(channel).topic
       end
 
       def topic
         @topic ||= channel.topic(EventBus::Config::TOPIC, topic_options)
       end
 
-      def self.produce(connection, event)
-        new(connection).produce(event)
+      def self.produce(channel, event)
+        new(channel).produce(event)
       end
 
       def produce(event)

--- a/lib/event_bus/version.rb
+++ b/lib/event_bus/version.rb
@@ -1,3 +1,3 @@
 module EventBus
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end

--- a/spec/event_bus_spec.rb
+++ b/spec/event_bus_spec.rb
@@ -1,5 +1,5 @@
 describe EventBus do
   it 'has a version number' do
-    expect(EventBus::VERSION).to eq '2.0.2'
+    expect(EventBus::VERSION).to eq '2.0.3'
   end
 end


### PR DESCRIPTION
This fixes a bug that happens if for some reason the channel closes, which was causing all subsequent channel calls to fail until the app was restarted.

We jumped into a situation where Rabbit would close the channel, causing the above.